### PR TITLE
Add argument for suppressing celltoolbar in output

### DIFF
--- a/nb-filter-cells
+++ b/nb-filter-cells
@@ -35,6 +35,11 @@ def main() -> None:
         default="exercise",
         help="tag to filter out",
     )
+    parser.add_argument(
+        "--show-celltoolbar",
+        action="store_true",
+        help="show the cell toolbar in output notebook (default: False)",
+    )
     args = parser.parse_args()
     notebook = nbformat.read(args.input, as_version=nbformat.NO_CONVERT)
     filtered_cells = []
@@ -42,6 +47,10 @@ def main() -> None:
         if "tags" in cell["metadata"] and args.tag in cell["metadata"]["tags"]:
             continue
         filtered_cells.append(cell)
+    if not args.show_celltoolbar:
+        metadata = notebook["metadata"]
+        if "celltoolbar" in metadata:
+            metadata.pop("celltoolbar")
     notebook["cells"] = filtered_cells
     nbformat.write(notebook, args.output)
 


### PR DESCRIPTION
This PR adds an argument for optionally hiding the cell toolbar in the output notebooks. So instead of

![image](https://user-images.githubusercontent.com/15220906/51600333-9eb71780-1ef9-11e9-9453-3ae446b1a441.png)

you get

![image](https://user-images.githubusercontent.com/15220906/51600358-abd40680-1ef9-11e9-9769-b7d3369c53f6.png)

Very happy for your input on whether this should be on by default, and any other changes you might want to make to the interface. In particular typing out `--hide-celltoolbar` each time is probably a bit annoying.